### PR TITLE
add responsive desktop message component for non-mobile/tablet users

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,20 +1,25 @@
-
-<!-- <app-following-post /> -->
+<div *ngIf="isMobileView;">
   <router-outlet/>
 
-<div *ngIf="showCreateOverlay" class="fixed top-0  w-screen h-screen bg-gray-800 bg-opacity-50 flex justify-center items-center z-[1000]">
-  <div class="flex flex-col p-5 rounded-lg shadow-lg w-screen max-w-4xl relative">
-    <div class="flex justify-between items-start">
-      <app-create-posts></app-create-posts>
-      <button class="w-8 h-8 bg-transparent border-none" (click)="closeCreateOverlay()">
-        <svg viewBox="0 0 24 24" class="w-4 h-4" fill="white" xmlns="http://www.w3.org/2000/svg">
-          <path d="M5.3,18.7C5.5,18.9,5.7,19,6,19s0.5-0.1,0.7-0.3l5.3-5.3l5.3,5.3c0.2,0.2,0.5,0.3,0.7,0.3
-              s0.5-0.1,0.7-0.3c0.4-0.4,0.4-1,0-1.4L13.4,12l5.3-5.3c0.4-0.4,0.4-1,0-1.4s-1-0.4-1.4,0L12,10.6
-              L6.7,5.3c-0.4-0.4-1-0.4-1.4,0s-0.4,1,0,1.4l5.3,5.3l-5.3,5.3C4.9,17.7,4.9,18.3,5.3,18.7z"/>
-        </svg>
-      </button>
+  <div *ngIf="showCreateOverlay" class="fixed top-0  w-screen h-screen bg-gray-800 bg-opacity-50 flex justify-center items-center z-[1000]">
+    <div class="flex flex-col p-5 rounded-lg shadow-lg w-screen max-w-4xl relative">
+      <div class="flex justify-between items-start">
+        <app-create-posts></app-create-posts>
+        <button class="w-8 h-8 bg-transparent border-none" (click)="closeCreateOverlay()">
+          <svg viewBox="0 0 24 24" class="w-4 h-4" fill="white" xmlns="http://www.w3.org/2000/svg">
+            <path d="M5.3,18.7C5.5,18.9,5.7,19,6,19s0.5-0.1,0.7-0.3l5.3-5.3l5.3,5.3c0.2,0.2,0.5,0.3,0.7,0.3
+                s0.5-0.1,0.7-0.3c0.4-0.4,0.4-1,0-1.4L13.4,12l5.3-5.3c0.4-0.4,0.4-1,0-1.4s-1-0.4-1.4,0L12,10.6
+                L6.7,5.3c-0.4-0.4-1-0.4-1.4,0s-0.4,1,0,1.4l5.3,5.3l-5.3,5.3C4.9,17.7,4.9,18.3,5.3,18.7z"/>
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
 </div>
+
+<div #desktopMessage>
+  <app-desktop-message></app-desktop-message>
+</div>
+
 
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,17 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { CommonModule } from '@angular/common'
 import { CreateOverlayService } from './services/create-overlay.service';
 import { CreatePostsComponent } from "./components/create-posts/create-posts.component";
+import { DesktopMessageComponent } from './components/desktop-message/desktop-message.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, CommonModule, CreatePostsComponent],
+  imports: [RouterOutlet, CommonModule, CreatePostsComponent, DesktopMessageComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   showCreateOverlay: boolean = false;
+  isMobileView: boolean = true;
 
   constructor(private overlayService: CreateOverlayService) {}
 
@@ -19,6 +21,13 @@ export class AppComponent {
     this.overlayService.overlayState$.subscribe((state) => {
       this.showCreateOverlay = state;
     });
+
+    this.checkViewport();
+    window.addEventListener('resize', this.checkViewport.bind(this));
+  }
+
+  checkViewport() {
+    this.isMobileView = window.innerWidth <= 840;
   }
 
   closeCreateOverlay(): void {

--- a/src/app/components/desktop-message/desktop-message.component.html
+++ b/src/app/components/desktop-message/desktop-message.component.html
@@ -1,0 +1,9 @@
+<div class="flex items-center justify-center min-h-screen bg-gray-900 text-white text-center px-4">
+  <div class="max-w-md">
+    <h2 class="text-2xl font-semibold mb-4">Welcome!</h2>
+    <p class="text-base leading-relaxed">
+      We’ve designed this social platform for the best experience on mobile and tablet devices.<br>
+      Please switch to a smaller screen to continue enjoying all our features. 💫
+    </p>
+  </div>
+</div>

--- a/src/app/components/desktop-message/desktop-message.component.ts
+++ b/src/app/components/desktop-message/desktop-message.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-desktop-message',
+  imports: [],
+  templateUrl: './desktop-message.component.html',
+  styleUrl: './desktop-message.component.css'
+})
+export class DesktopMessageComponent {
+
+}


### PR DESCRIPTION
- Created a `DesktopMessageComponent` to display a polite notice for users on screens wider than 650px
- Updated `AppComponent` to conditionally render the main app or desktop message based on screen width
- Applied Tailwind CSS to center and style the message with a clean, white-on-dark design
- Ensures optimal user experience by guiding users to access the app on mobile or tablet devices